### PR TITLE
[#20] Nullify totalSupply during BurnAll

### DIFF
--- a/src/Indigo/Contracts/Holdings/Impl.hs
+++ b/src/Indigo/Contracts/Holdings/Impl.hs
@@ -136,6 +136,7 @@ holdingsIndigo param = contractName "Holdings" $ do
         ensureSenderIsAdmin
         ensureNotPaused
         setField_ storage #ledger emptyBigMap
+        setStorageField @Storage #totalSupply (0 :: Natural)
     , #cSetPause //-> \pausedNamed -> do
         -- admin check is already done in Lorentz code
         let paused = UnName #value pausedNamed

--- a/test/Test/Indigo/Contracts/Holdings.hs
+++ b/test/Test/Indigo/Contracts/Holdings.hs
@@ -392,6 +392,16 @@ test_burnAndBurnAll = testGroup "Test Burn and BurnAll entrypoints"
       withSender ownerAddress $ lCallDef h (SetPause $ #value .! True)
       withSender ownerAddress $ lCallDef h $ BurnAll ()
       validate . Left $ lExpectCustomError_ #tokenOperationsArePaused
+  , testCase "BurnAll nullifies totalSupply" $
+    integrationalTestExpectation $ do
+      h <- originateHoldings ownerAddress $ Nothing
+      consumer <- lOriginateEmpty contractConsumer "consumer"
+      withSender ownerAddress $ lCallDef h $ Mint (#to .! ownerAddress, #value .! 100)
+      lCallDef h $ GetTotalSupply (mkView () consumer)
+      withSender ownerAddress $ lCallDef h $ BurnAll ()
+      lCallDef h $ GetTotalSupply (mkView () consumer)
+      validate . Right $
+        lExpectViewConsumerStorage consumer [100, 0]
   ]
 
 test_setPauseAndSetTransferable :: TestTree


### PR DESCRIPTION
## Description
Problem: We forgot to set totalSupply to 0 in burnAll.

Solution: Set it to 0. Add test case.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #20

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
