### PR TITLE
[#22] Split 'transfer' into 'transfer' and 'seize'

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -71,7 +71,7 @@ holdingsStorageParser = do
     (#help .! "Initial token symbol.")
   tmId <- mTextOption (Just [mt|Token-id|]) (#name .! "token-id")
     (#help .! "Initial token id.")
-  pure $ H.mkStorage owner admin mbSafelist H.TokenMeta{..}
+  pure $ H.mkStorage owner admin mbSafelist mempty 0 H.TokenMeta{..}
   where
     mbAddressOption :: String -> String -> Opt.Parser (Maybe Address)
     mbAddressOption name hInfo = optional $

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -78,6 +78,10 @@ Required `Holdings` entrypoints:
   * Description: returns `True` if the address is admin.
 * `transfer (address :from, address :to, nat :value)`
   * Description: transfer given amount of tokens from one address to another.
+  * Constraints: `isNotPaused`, `isTransferable`.
+  * Safelist constraints: `assertTransfer` passes.
+* `seize (address :from, address :to, nat :value)`
+  * Description: forcefully transfer funds from one address to another.
   * Constraints: `onlyAdmin`, `isNotPaused`, `isTransferable`.
   * Safelist constraints: `assertTransfer` passes.
 * `approve (address :spender, nat :value)`

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -34,7 +34,6 @@ _definitions:
         - GADTs
         - GeneralizedNewtypeDeriving
         - LambdaCase
-        - MonadFailDesugaring
         - MultiParamTypeClasses
         - MultiWayIf
         - NamedFieldPuns

--- a/nix/nixpkgs-with-haskell-nix.nix
+++ b/nix/nixpkgs-with-haskell-nix.nix
@@ -3,6 +3,6 @@
 
 let
   sources = import ./sources.nix;
-  haskellNixArgs = import sources."haskell.nix";
+  haskellNix = import sources."haskell.nix" {};
   nixpkgs = import sources.nixpkgs;
-in nixpkgs haskellNixArgs
+in nixpkgs haskellNix.nixpkgsArgs

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "98ac006e995d310c9329787bd93f6c3384174713",
-        "sha256": "01v80m0m59csjacbax8z0k2mlx6vww0wh5qnmgcwdq9zfa5d3g81",
+        "rev": "e5089734b7ae0610f51fe1f99bde1616d873689a",
+        "sha256": "06myjcaml1lpgq0yiqksl8ybzai67gnsvwg9fhqmv478jrlp0m45",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/98ac006e995d310c9329787bd93f6c3384174713.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/e5089734b7ae0610f51fe1f99bde1616d873689a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "45c5124eab8b6272b6d868fefe405d8031c16846",
-        "sha256": "0mrx31aswr58jwdfsklhi945yw6iz2rbqiiapydrz8frfclk9yry",
+        "rev": "f8a2e9f2c1360a90010706945c1edcd165ceed8d",
+        "sha256": "0laa1gba3yah1hcvdf5hylfdgz90nll5bqzhc43ri018vvak5f47",
         "type": "tarball",
-        "url": "https://github.com/serokell/nixpkgs/archive/45c5124eab8b6272b6d868fefe405d8031c16846.tar.gz",
+        "url": "https://github.com/serokell/nixpkgs/archive/f8a2e9f2c1360a90010706945c1edcd165ceed8d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/package.yaml
+++ b/package.yaml
@@ -61,9 +61,11 @@ tests:
       - lorentz
       - morley
       - morley-ledgers
+      - morley-ledgers-test
       - morley-nettest
       - morley-prelude
       - tasty
+      - tasty-hspec
       - tasty-hunit-compat
 
   globacap-nettest:

--- a/src/Indigo/Contracts/Holdings/Types.hs
+++ b/src/Indigo/Contracts/Holdings/Types.hs
@@ -159,6 +159,7 @@ data Parameter
   | AcceptAdminRights ()
   | IsAdmin (View Address Bool)
   | Transfer ML.TransferParams
+  | Seize ML.TransferParams
   | Approve ML.ApproveParams
   | GetAllowance (View ML.GetAllowanceParams Natural)
   | GetBalance (View ML.GetBalanceParams Natural)

--- a/src/Indigo/Contracts/Holdings/Types.hs
+++ b/src/Indigo/Contracts/Holdings/Types.hs
@@ -14,6 +14,7 @@ where
 
 import Indigo
 
+import qualified Data.Map as Map
 import Fmt (Buildable(..), (+|), (|+))
 
 import qualified Lorentz.Contracts.ManagedLedger.Types as ML
@@ -135,9 +136,11 @@ tokenMetaNotes = NTPair noAnn (ann "name") noAnn
 ledgerEntryNotes :: Notes (ToT ML.LedgerValue)
 ledgerEntryNotes = NTPair noAnn (ann "balance") (ann "approvals") starNotes starNotes
 
-mkStorage :: Address -> Address -> Maybe Address -> TokenMeta -> Storage
-mkStorage owner admin mbSafelist meta =
-  ML.mkStorageSkeleton mempty fields
+mkStorage
+  :: Address -> Address -> Maybe Address -> [(Address, Natural)] -> Natural
+  -> TokenMeta -> Storage
+mkStorage owner admin mbSafelist balances totalSupply meta =
+  ML.mkStorageSkeleton (Map.fromList balances) fields
   where
     fields :: StorageFields
     fields = StorageFields
@@ -148,7 +151,7 @@ mkStorage owner admin mbSafelist meta =
       , sfMbNewAdmin = Nothing
       , sfPaused = False
       , sfTransferable = True
-      , sfTotalSupply = 0
+      , sfTotalSupply = totalSupply
       }
 
 data Parameter

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@
 #
 # when updating git dependencies, please run
 # nix run -f https://github.com/serokell/scratch/archive/master.tar.gz scripts.update-stack-shas -c update-stack-shas
-resolver: lts-14.15
+resolver: lts-15.7
 
 packages:
 - .
@@ -14,8 +14,8 @@ extra-deps:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    647cc5ad3b3f07a30f6ead75ea91449d780adc4f # master
-  # nix-sha256: 1rxrmfnxh8d9xhkh3pi53k7h5rzph0riy0nh7hkm6w20nvffym4z
+    d844c99229a61d6d4862585636e6b8df8409f349 # master
+  # nix-sha256: 1da0n8jgb0p3c5aw94qaa79f4ycxqpdb7rbs7klia2rd1b3r5l4f
   subdirs:
     - code/morley
     - code/indigo
@@ -27,35 +27,38 @@ extra-deps:
     - code/morley-client
     - code/morley-nettest
 
-- git:
-    https://gitlab.com/obsidian.systems/tezos-bake-monitor-lib.git
-  commit:
-    19a9ce57a0510bc3ad8a3f639d0a968a65024b86
-  # nix-sha256: 0ypf7z2c9w59rz7hymzdyx87783qdfp3kygs9jl8qnmbfslmi8jr
-  subdirs:
-    - tezos-bake-monitor-lib
-
 # Stable parts of morley available from Hackage
 - morley-prelude-0.3.0
 - tasty-hunit-compat-0.2
 
 # Required by morley
-- show-type-0.1.1@sha256:24f681a3481b3f9630e619d816054804ba1bd6cc05b5978ddd2cece8499ff2fa
 - aeson-options-0.1.0
 - base58-bytestring-0.1.0
 - hex-text-0.1.0.0
-- constraints-0.11@sha256:44f80a313d5d4fcfb3c18eb6625dd3db4bb845d5ca8d3b1f62125a4b7241e590
-- o-clock-1.1.0@sha256:941ac2bc1732e6622b165831c4badb1a8e846f451620bd028064339f5b284224
-- pretty-terminal-0.1.0.0@sha256:e9135d86ebb2a8e3aaf5a79088de4628dbd49988388e0fbfc26c5ecb3c399ad9
+- pretty-terminal-0.1.0.0
+- show-type-0.1.1
 - git: https://github.com/int-index/caps.git
-  commit: ab4345eabd58fc6f05d3b46bea2c5acdba3ec6f8
-  # nix-sha256: 0r1zqa559gaxavsd8zynlpa2c5hi2qc20n8s4bhcdaw36hasg3kr
-# Required by tezos-bake-monitor-lib
-- functor-infix-0.0.5@sha256:cea21a321031f556d7a21b51e049493e7cb78baf64dd63f0d1a36de01c4c735b
+  commit: c5d61837eb358989b581ed82b1e79158c4823b1b
+  # nix-sha256: 0vkhsw1jsyzhk1kimn2g34fms60kms0m9g4r4mr46pavhak5qzsx
+# tezos-bake-monitor-lib and its deps which are used in morley-client
+- git:
+    https://gitlab.com/obsidian.systems/tezos-bake-monitor-lib.git
+  commit:
+    ed3280836d7d0e87999639520610bf7b6510e743
+  # nix-sha256: 1x15x21vd5fmka14br1n95nwwj9fmjgc6x1kwjywi95y9f9zxz3x
+  subdirs:
+    - tezos-bake-monitor-lib
+- witherable-0.3.5
+- witherable-class-0
+- monoidal-containers-0.6.0.1
 - hashing-0.1.0.1@sha256:98861f16791946cdf28e3c7a6ee9ac8b72d546d6e33c569c7087ef18253294e7
-- dependent-sum-0.6.2.0
-- dependent-sum-template-0.1.0.0
+- dependent-sum-0.7.1.0
+- dependent-sum-template-0.1.0.3
 - constraints-extras-0.3.0.2@sha256:bf6884be65958e9188ae3c9e5547abfd6d201df021bff8a4704c2c4fe1e1ae5b
+- base-noprelude-4.13.0.0@sha256:3cccbfda38e1422ca5cc436d58858ba51ff9114d2ed87915a6569be11e4e5a90,6842
+- fmt-0.6.1.2@sha256:405a1bfc0ba0fd99f6eb1ee71f100045223f79204f961593012f28fd99cd1237,5319
+- named-0.3.0.1@sha256:69b9722301201f8ed8abc89c4595e22c746e944bf4cdfafa8b21b14d336b26d1,2233
+- vinyl-0.12.1@sha256:43456d4b3009646eee63953cbe539f1f4d0caf8bc3c25e841117e712836508f3,3790
 
 # Required by globacap
 - with-utf8-1.0.0.0@sha256:686e47588986d8080451b4e617118b579487dd4e085bba7bb36fac4198c90ae6

--- a/test-common/Nettest/WhitelistIntegration.hs
+++ b/test-common/Nettest/WhitelistIntegration.hs
@@ -13,7 +13,6 @@ import Michelson.Typed.Convert (untypeValue)
 import Michelson.Typed.Haskell.Value (BigMap(..), IsoValue(..))
 import qualified Michelson.Untyped as U
 import Morley.Nettest
-import Morley.Nettest.Caps (originateUntypedSimple)
 import Util.Named
 
 import Indigo.Contracts.Holdings
@@ -60,7 +59,7 @@ whitelistScenario whitelistContract = uncapsNettest $ do
       ]
     ) whitelistContract
   holdingsAddr :: Address <- originateSimple "Holdings"
-    (mkStorage ownerAddr ownerAddr Nothing dummyMeta) holdingsContract
+    (mkStorage ownerAddr ownerAddr Nothing mempty 0 dummyMeta) holdingsContract
   let
     owner, sender, holdings :: AddrOrAlias
     owner = AddrResolved ownerAddr

--- a/test/Test/Indigo/Contracts/Common.hs
+++ b/test/Test/Indigo/Contracts/Common.hs
@@ -3,13 +3,17 @@
 -- SPDX-License-Identifier: LicenseRef-Proprietary
 module Test.Indigo.Contracts.Common
   ( expectStorageUpdate
+  , originateHoldings
+  , originateHoldingsWithAlSettings
   , originateSafelist
   ) where
 
 import Lorentz (Address, NiceStorage, TAddress(..), ToAddress)
+import Lorentz.Contracts.Test (AlSettings(..))
 import Lorentz.Test
 import Tezos.Core (toMutez)
 
+import qualified Indigo.Contracts.Holdings as H
 import qualified Indigo.Contracts.Safelist as SL
 
 originateSafelist
@@ -17,6 +21,19 @@ originateSafelist
 originateSafelist transfers receivers =
   lOriginate SL.safelistContract "safelist" (SL.mkStorage transfers receivers) (toMutez 0)
 
+originateHoldingsWithAlSettings
+  :: Address -> AlSettings -> IntegrationalScenarioM (TAddress H.Parameter)
+originateHoldingsWithAlSettings admin (AlInitAddresses initAddresses) =
+  lOriginate H.holdingsContract "holdings"
+  (H.mkStorage admin admin Nothing initAddresses (sum $ map snd initAddresses) H.dummyMeta)
+  (toMutez 0)
+
+originateHoldings
+  :: Address -> Maybe Address
+  -> IntegrationalScenarioM (TAddress H.Parameter)
+originateHoldings owner mbSafelist =
+  lOriginate H.holdingsContract "holdings"
+  (H.mkStorage owner owner mbSafelist mempty 0 H.dummyMeta) (toMutez 0)
 
 expectStorageUpdate
   :: (ToAddress addr, NiceStorage st)

--- a/test/Test/Indigo/Contracts/Holdings.hs
+++ b/test/Test/Indigo/Contracts/Holdings.hs
@@ -8,26 +8,28 @@ module Test.Indigo.Contracts.Holdings
   , test_mint
   , test_approve
   , test_transfer
+  , test_seize
   , test_burnAndBurnAll
   , test_setPauseAndSetTransferable
   , test_documentation
   , unit_FA1'2_is_implemented
   , unit_nettest_scenario
   , unit_whitelist_integration
+  , test_approvableLedger
   ) where
 
 import Test.Hspec (Expectation)
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hspec (testSpec)
 import Test.Tasty.HUnit (Assertion, testCase)
 
-import Lorentz (Address, TAddress(..), ToAddress(..), mkView, mt)
+import Lorentz (Address, ToAddress(..), mkView, mt)
 import qualified Lorentz.Contracts.ManagedLedger.Types as ML
 import qualified Lorentz.Contracts.Spec.ApprovableLedgerInterface as AL
+import Lorentz.Contracts.Test (approvableLedgerSpec)
 import Lorentz.Test
 import Michelson.Runtime (prepareContract)
-import Michelson.Runtime.GState (genesisAddress, genesisAddress1, genesisAddress2)
 import Morley.Nettest
-import Tezos.Core (toMutez)
 import Util.Named ((.!))
 
 import Indigo.Contracts.Holdings
@@ -35,12 +37,6 @@ import Indigo.Contracts.Holdings
 import Nettest.Holdings
 import Nettest.WhitelistIntegration
 import Test.Indigo.Contracts.Common
-
-originateHoldings
-  :: Address -> Maybe Address -> IntegrationalScenarioM (TAddress Parameter)
-originateHoldings owner mbSafelist =
-  lOriginate holdingsContract "holdings"
-  (mkStorage owner owner mbSafelist dummyMeta) (toMutez 0)
 
 ownerAddress :: Address
 ownerAddress = genesisAddress
@@ -528,3 +524,8 @@ unit_whitelist_integration = do
   whitelistContract <- prepareContract $ Just "resources/whitelist.tz"
   integrationalTestExpectation $
     nettestToIntegrational (whitelistScenario whitelistContract)
+
+test_approvableLedger :: IO TestTree
+test_approvableLedger =
+  testSpec "Holdings contract without safelist ledger tests" $
+  approvableLedgerSpec originateHoldingsWithAlSettings

--- a/test/Test/Indigo/Contracts/SMT.hs
+++ b/test/Test/Indigo/Contracts/SMT.hs
@@ -1,0 +1,18 @@
+-- SPDX-FileCopyrightText: 2020 TBD
+--
+-- SPDX-License-Identifier: LicenseRef-Proprietary
+module Test.Indigo.Contracts.SMT
+  ( test_holdingsApprovableLedgerSMT
+  ) where
+
+import Test.Tasty (TestTree)
+
+import Lorentz.Contracts.Test (approvableLedgerSMT)
+
+import Test.Indigo.Contracts.Common
+
+-- | Without safelist checks our contract should satisfy state machine
+-- tests for compliance to FA1.2/Approvable Ledger interface.
+test_holdingsApprovableLedgerSMT :: [TestTree]
+test_holdingsApprovableLedgerSMT =
+  approvableLedgerSMT originateHoldingsWithAlSettings

--- a/test/Test/Indigo/Contracts/Safelist.hs
+++ b/test/Test/Indigo/Contracts/Safelist.hs
@@ -9,7 +9,6 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
 import Lorentz.Test
-import Michelson.Runtime.GState (genesisAddress, genesisAddress1, genesisAddress2)
 import Util.Named ((.!))
 
 import Indigo.Contracts.Safelist


### PR DESCRIPTION
## Description
`transfer` entrypoint was split into `transfer` (which is now callable by anyone) and `seize` 
(which is callable only by admin).

Since `transfer` became callable by anyone, ApprovableLedger interface tests from `morley-ledgers-test` were added.

~`seize` currently doesn't consume allowance, however, there is a small chance that it can be changed.~
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #22 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
