### PR TITLE
[OPS-1023] CI: update dependencies, pin hackage and stackage indexes independently

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -106,8 +106,16 @@ rec {
       globacap document --name Holdings --output Holdings-contract.md
     '';
 
+  # nixpkgs has weeder 2, but we use weeder 1
+  weeder-legacy = pkgs.haskellPackages.callHackageDirect {
+    pkg = "weeder";
+    ver = "1.0.9";
+    sha256 = "0gfvhw7n8g2274k74g8gnv1y19alr1yig618capiyaix6i9wnmpa";
+  } {};
+
   # a derivation which generates a script for running weeder
   weeder-script = weeder-hacks.weeder-script {
+    weeder = weeder-legacy;
     hs-pkgs = hs-pkgs-development;
     local-packages = local-packages;
   };

--- a/nix/nixpkgs-with-haskell-nix.nix
+++ b/nix/nixpkgs-with-haskell-nix.nix
@@ -3,6 +3,8 @@
 
 let
   sources = import ./sources.nix;
-  haskellNix = import sources."haskell.nix" {};
+  haskellNix = import sources."haskell.nix" {
+    sourceOverrides = { hackage = sources."hackage.nix"; stackage = sources."stackage.nix"; };
+  };
   nixpkgs = import sources.nixpkgs;
 in nixpkgs haskellNix.nixpkgsArgs

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,26 +1,14 @@
 {
-    "xrefcheck": {
-        "branch": "master",
-        "description": "Check cross-references in repository documents",
-        "homepage": "",
-        "owner": "serokell",
-        "repo": "xrefcheck",
-        "rev": "b54c38d91bd45e5c402ebf51d68c653faf959c2c",
-        "sha256": "08317j8zzypwnvdixcby84ccbdzhgli4cpfrms4bpnfnqvcrawfb",
-        "type": "tarball",
-        "url": "https://github.com/serokell/xrefcheck/archive/b54c38d91bd45e5c402ebf51d68c653faf959c2c.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "haskell-nix-weeder": {
         "branch": "master",
         "description": "haskell.nix + weeder",
         "homepage": null,
         "owner": "serokell",
         "repo": "haskell-nix-weeder",
-        "rev": "7f11f514b54474c3281b25ac2c09975c918e0492",
-        "sha256": "0nww0cx8sjn8gg5k6371f17kdbp72nmdz34hwa9sxwvrmxzagg2x",
+        "rev": "a959fce7499df473e13336959cba77fbc87f3b7f",
+        "sha256": "1pmlndvbhzxj1k5f87d9dxfa00zbvmkmvnbd1davzwg77bd639l0",
         "type": "tarball",
-        "url": "https://github.com/serokell/haskell-nix-weeder/archive/7f11f514b54474c3281b25ac2c09975c918e0492.tar.gz",
+        "url": "https://github.com/serokell/haskell-nix-weeder/archive/a959fce7499df473e13336959cba77fbc87f3b7f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
@@ -29,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e5089734b7ae0610f51fe1f99bde1616d873689a",
-        "sha256": "06myjcaml1lpgq0yiqksl8ybzai67gnsvwg9fhqmv478jrlp0m45",
+        "rev": "f4136211c933b444ab2e0f358abd223929970220",
+        "sha256": "1b9nxzkg29hwczr6pb6a7arxka8z0swzq7b2bqyxqzr4qvpcjlc1",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/e5089734b7ae0610f51fe1f99bde1616d873689a.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/f4136211c933b444ab2e0f358abd223929970220.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -41,10 +29,10 @@
         "homepage": "",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "f8a2e9f2c1360a90010706945c1edcd165ceed8d",
-        "sha256": "0laa1gba3yah1hcvdf5hylfdgz90nll5bqzhc43ri018vvak5f47",
+        "rev": "ec2598d025b7670472175413748ce688a60712b9",
+        "sha256": "0b1acpgy9jbf57zxqk0zqza7yk2a70q8mrhd519rq8kmgc95dw1x",
         "type": "tarball",
-        "url": "https://github.com/serokell/nixpkgs/archive/f8a2e9f2c1360a90010706945c1edcd165ceed8d.tar.gz",
+        "url": "https://github.com/serokell/nixpkgs/archive/ec2598d025b7670472175413748ce688a60712b9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos-packaging": {
@@ -57,6 +45,18 @@
         "sha256": "03z4c3f9mf113xiszbns8rs0l4adl4jw657cdcrjbsjnr7xpdv5m",
         "type": "tarball",
         "url": "https://github.com/serokell/tezos-packaging/archive/84a3d6cee45912503d2c0dbb96d1b476ce01b47c.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "xrefcheck": {
+        "branch": "master",
+        "description": "Check cross-references in repository documents",
+        "homepage": "",
+        "owner": "serokell",
+        "repo": "xrefcheck",
+        "rev": "b54c38d91bd45e5c402ebf51d68c653faf959c2c",
+        "sha256": "08317j8zzypwnvdixcby84ccbdzhgli4cpfrms4bpnfnqvcrawfb",
+        "type": "tarball",
+        "url": "https://github.com/serokell/xrefcheck/archive/b54c38d91bd45e5c402ebf51d68c653faf959c2c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "hackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions for Hackage",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "6be2e8a47504a4753dc8786bdc401ace902869cd",
+        "sha256": "1dj3ks79jnh2w2npy8q0yaxngcz0d5r8l8ihqgy7afjy7wpmn1gm",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/6be2e8a47504a4753dc8786bdc401ace902869cd.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "haskell-nix-weeder": {
         "branch": "master",
         "description": "haskell.nix + weeder",
@@ -33,6 +45,18 @@
         "sha256": "0b1acpgy9jbf57zxqk0zqza7yk2a70q8mrhd519rq8kmgc95dw1x",
         "type": "tarball",
         "url": "https://github.com/serokell/nixpkgs/archive/ec2598d025b7670472175413748ce688a60712b9.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "stackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions of Stackage snapshots",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "f50e24fa7a734f2291e8d940be33d917aa7456ad",
+        "sha256": "0rw35vllm81nnmvjqsl09qs00bw7gmj965p88rd250n80nv1g5c9",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/stackage.nix/archive/f50e24fa7a734f2291e8d940be33d917aa7456ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos-packaging": {


### PR DESCRIPTION
## Description

Makes sure that haskell.nix revision used in CI is the same as most of our other projects have, to reduce number of ghc builds
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->
OPS-1023

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
