### PR TITLE
Run nettest jobs on a separate agent to not stall CI for regular jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,6 +64,9 @@ steps:
 
   - label: nettest-scheduled-carthagenet
     if: build.source == "schedule"
+    # use another agent for long scheduled jobs
+    agents:
+      queue: "scheduled"
     env:
       NETTEST_NODE_ADDR: "carthage.testnet.tezos.serokell.team"
       NETTEST_NODE_PORT: "8732"
@@ -75,6 +78,8 @@ steps:
 
   - label: nettest-scheduled-delphinet
     if: build.source == "schedule"
+    agents:
+      queue: "scheduled"
     env:
       NETTEST_NODE_ADDR: "delphi.testnet.tezos.serokell.team"
       NETTEST_NODE_PORT: "8732"


### PR DESCRIPTION


## Description

Problem: scheduled nettest job takes a long time to finish, making other
CI jobs wait for it

Solution: use a special runner for the nettest job

Needs https://github.com/serokell/serokell-profiles/pull/540 to be deployed first
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/OPS-1066

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
