### PR TITLE
Disable testing on 006 protocol

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,11 +49,11 @@ steps:
     - nix-build ci.nix -A packages.globacap.tests.globacap-test
     - ./result/bin/globacap-test
 
-  - label: nettest-local-chain-006
+  - label: nettest-local-chain-007
     if: *not_scheduled_not_autodoc
     env:
       NETTEST_NODE_ADDR: "localhost"
-      NETTEST_NODE_PORT: "8734"
+      NETTEST_NODE_PORT: "8735"
       MONEYBAG: "unencrypted:edsk3AvAoPS5jFov49aWBQ9oVtCPwNSne2CriHvkFxfeCg4Srr5bak"
     commands: &run-nettest
     - nix-build ci.nix -A packages.globacap.tests.globacap-nettest
@@ -62,37 +62,16 @@ steps:
       automatic:
         limit: 1
 
-  - label: nettest-local-chain-007
-    if: *not_scheduled_not_autodoc
-    env:
-      NETTEST_NODE_ADDR: "localhost"
-      NETTEST_NODE_PORT: "8735"
-      MONEYBAG: "unencrypted:edsk3AvAoPS5jFov49aWBQ9oVtCPwNSne2CriHvkFxfeCg4Srr5bak"
-    commands: *run-nettest
-    retry: *retry-nettest
-
-  - label: nettest-scheduled-carthagenet
+  - label: nettest-scheduled-delphinet
     if: build.source == "schedule"
     # use another agent for long scheduled jobs
     agents:
       queue: "scheduled"
     env:
-      NETTEST_NODE_ADDR: "carthage.testnet.tezos.serokell.team"
-      NETTEST_NODE_PORT: "8732"
-      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
-      # more tz, its address: tz1VwWdetdADCEMySCumYXWtvf9pZQV3CmE5
-      MONEYBAG: "unencrypted:edsk4boUjEukc4THSkxiS32KrLEgQDcZmWg3YMhhdTfBF7fxKJAhdq"
-    commands: *run-nettest
-    retry: *retry-nettest
-
-  - label: nettest-scheduled-delphinet
-    if: build.source == "schedule"
-    agents:
-      queue: "scheduled"
-    env:
       NETTEST_NODE_ADDR: "delphi.testnet.tezos.serokell.team"
       NETTEST_NODE_PORT: "8732"
-      # Same as in carthagenet
+      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
+      # more tz, its address: tz1NCV82ThTCF1vU2KEGv3ZeZw4hhAPbD5UM
       MONEYBAG: "unencrypted:edsk3UH7bwt2i3D6VQCmT8ZkMufdFEqJr79StJjguuk6W4wZccSp9J"
     commands: *run-nettest
     retry: *retry-nettest


### PR DESCRIPTION
## Description

Problem: 007 protocol will soon be activated on mainnet, as a
consequence carthagenet will die.

Solution: Remove testing on 006 protocol because it's outdated.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TM-478

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
