### PR TITLE
Don't use global variable with MONEYBAG

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,6 @@
 
 env:
   TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER: "Y"
-  MONEYBAG: "unencrypted:edsk3AvAoPS5jFov49aWBQ9oVtCPwNSne2CriHvkFxfeCg4Srr5bak"
 
 steps:
   - label: hlint
@@ -54,6 +53,7 @@ steps:
     if: *not_scheduled_not_autodoc
     env:
       NETTEST_NODE_ENDPOINT: "http://localhost:8735"
+      MONEYBAG: "unencrypted:edsk3AvAoPS5jFov49aWBQ9oVtCPwNSne2CriHvkFxfeCg4Srr5bak"
     commands: &run-nettest
     - nix-build ci.nix -A packages.globacap.tests.globacap-nettest
     - nix run -f ci.nix tezos-client -c ./scripts/ci/run-local-chain-nettest.sh result/bin/globacap-nettest
@@ -65,6 +65,7 @@ steps:
     if: *not_scheduled_not_autodoc
     env:
       NETTEST_NODE_ENDPOINT: "http://localhost:8734"
+      MONEYBAG: "unencrypted:edsk3AvAoPS5jFov49aWBQ9oVtCPwNSne2CriHvkFxfeCg4Srr5bak"
     commands: *run-nettest
     retry: *retry-nettest
 


### PR DESCRIPTION
## Description
Problem: Local env variables for each job seem to not override the
global pipeline env for some reason, thus defining moneybag key both
globally and locally doesn't work and the global one is always chosen.

Solution: Move moneybags back to the job envs.

See [this pipeline failure](https://buildkite.com/serokell/tezos-globacap/builds/552#4d5f7ba7-8d76-4cc8-af12-1888998a6d3f).
The log says that `tz1VPPpDoFYFJckEqR9J3UCz5crMHhsYrLw9` was added, while the actual moneybag address should be
`tz1NCV82ThTCF1vU2KEGv3ZeZw4hhAPbD5UM`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
